### PR TITLE
Fixed error where bundle ID was being set for bundle version

### DIFF
--- a/Assets/Stickers/Editor/StickersExport.cs
+++ b/Assets/Stickers/Editor/StickersExport.cs
@@ -98,7 +98,7 @@ namespace Agens.Stickers
                 name,
                 pack.BundleId,
                 PlayerSettings.iOS.appleDeveloperTeamID,
-                PlayerSettings.bundleIdentifier,
+                PlayerSettings.bundleVersion,
                 PlayerSettings.iOS.buildNumber,
                 GetTargetDeviceFamily(PlayerSettings.iOS.targetDevice),
                 pack.Signing.AutomaticSigning ? null : pack.Signing.ProvisioningProfile,


### PR DESCRIPTION
The sticker's plist file was showing the bundle id as the version number
due an incorrect variable placement