### PR TITLE
Typo fix for dev build with auto-sign

### DIFF
--- a/Assets/Stickers/Editor/PBXProject.cs
+++ b/Assets/Stickers/Editor/PBXProject.cs
@@ -1224,7 +1224,7 @@ namespace UnityEditor.iOS.Xcode.Stickers
             config.AddProperty("SKIP_INSTALL", "YES");
             if (automaticSigning)
             {
-                config.AddProperty("CODE_SIGN_IDENTITY[sdk=iphoneos*]", Debug.isDebugBuild ? "iPhone Development" : "iPhone Distribution");
+                config.AddProperty("CODE_SIGN_IDENTITY[sdk=iphoneos*]", Debug.isDebugBuild ? "iPhone Developer" : "iPhone Distribution");
             }
             config.AddProperty("INFOPLIST_FILE", infoPlistPath); // e.g. relative to source root "Stickers/Info.plist"
             config.AddProperty("PRODUCT_BUNDLE_IDENTIFIER", bundleId);


### PR DESCRIPTION
Hi, first of all thank you very much for this project and sharing it. 👍 

I'm proposing following change as it was causing and issue for me. Unity 2017.4.8f1 with XCode 9.4.1 when building with "Development Build" checked in Unity and auto signing selected in stickers. That change fixed the issue.