### PR TITLE
add trailing slash to fix build on macOS

### DIFF
--- a/Assets/Stickers/Editor/PBXProject.cs
+++ b/Assets/Stickers/Editor/PBXProject.cs
@@ -1044,7 +1044,7 @@ namespace UnityEditor.iOS.Xcode.Stickers
             proj.ReadFromString(File.ReadAllText(projPath));
             var targ = proj.TargetGuidByName(PBXProject.GetUnityTargetName());
 
-            CopyDirectory(extensionSourcePath, pathToBuiltProject + extensionGroupName, false);
+            CopyDirectory(extensionSourcePath, pathToBuiltProject + extensionGroupName + "/", false);
             if (proj.HasFramework("Messages.framework"))
             {
                 Debug.LogWarning("Xcode already contains a messages framework.");


### PR DESCRIPTION
This is only tested on macOS and it makes the build work again. Without the trailing slash the folder is not created but the name only prepended to the file names.