### PR TITLE
Update plugin to handle both App Store icon and Messages App Store icon

### DIFF
--- a/Assets/Stickers/Editor/StickerPackEditor.cs
+++ b/Assets/Stickers/Editor/StickerPackEditor.cs
@@ -66,7 +66,9 @@ namespace Agens.Stickers
         private static readonly GUIContent PixelSize = new GUIContent("Pixel Size");
         private static readonly GUIContent SizeOnDisk = new GUIContent("Size on disk");
         private static readonly GUIContent AppStoreIcon = new GUIContent("App Store Icon");
-        private static readonly GUIContent AppStoreIconSize = new GUIContent("1024 x 768");
+        private static readonly GUIContent AppStoreIconSize = new GUIContent("1024 x 1024");
+        private static readonly GUIContent MessagesAppStoreIcon = new GUIContent("Messages App Store Icon");
+        private static readonly GUIContent MessagesAppStoreIconSize = new GUIContent("1024 x 768");
         private static readonly GUIContent LoadFromFolder = new GUIContent("Load from Folder");
 
         private readonly Dictionary<Sticker, long> diskSizes = new Dictionary<Sticker, long>();
@@ -100,6 +102,7 @@ namespace Agens.Stickers
             iconProperties = new[]
             {
                 icons.FindPropertyRelative("appStore"),
+                icons.FindPropertyRelative("messagesAppStore"),
                 icons.FindPropertyRelative("messagesiPadPro2"),
                 icons.FindPropertyRelative("messagesiPad2"),
                 icons.FindPropertyRelative("messagesiPhone2"),
@@ -116,6 +119,7 @@ namespace Agens.Stickers
             iconTextureLabels = new[]
             {
                 new GUIContent("AppStore"),
+                new GUIContent("MessagesAppStore"),
                 new GUIContent("Messages iPad Pro @2x"),
                 new GUIContent("Messages iPad @2x"),
                 new GUIContent("Messages iPhone @2x"),
@@ -789,6 +793,15 @@ namespace Agens.Stickers
             iconProperties[0].objectReferenceValue = (Texture2D) EditorGUILayout.ObjectField(iconProperties[0].objectReferenceValue, typeof (Texture2D), false, GUILayout.Height(75) , GUILayout.Width(75));
             EditorGUILayout.EndHorizontal();
 
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.BeginVertical();
+            EditorGUILayout.LabelField(MessagesAppStoreIcon, boldLabelStyle);
+            EditorGUILayout.LabelField(MessagesAppStoreIconSize);
+            EditorGUILayout.EndVertical();
+
+            EditorGUI.BeginChangeCheck();
+            iconProperties[1].objectReferenceValue = (Texture2D)EditorGUILayout.ObjectField(iconProperties[1].objectReferenceValue, typeof(Texture2D), false, GUILayout.Height(75), GUILayout.Width(75));
+            EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.Space();
             EditorGUILayout.BeginHorizontal();
@@ -818,7 +831,7 @@ namespace Agens.Stickers
 
             DrawOverride();
 
-            for (int i = 1; i < iconProperties.Length; i++)
+            for (int i = 2; i < iconProperties.Length; i++)
             {
                 DrawIcons(i);
             }

--- a/Assets/Stickers/Editor/StickersExport.cs
+++ b/Assets/Stickers/Editor/StickersExport.cs
@@ -247,6 +247,7 @@ namespace Agens.Stickers
             CreateStickerIconElement(icon.Messages3Icon, images.AddDict());
 
             CreateStickerIconElement(icon.AppStoreIcon, images.AddDict());
+            CreateStickerIconElement(icon.MessagesAppStoreIcon, images.AddDict());
 
             return document;
         }

--- a/Assets/Stickers/StickerPackIcon.cs
+++ b/Assets/Stickers/StickerPackIcon.cs
@@ -24,6 +24,7 @@ namespace Agens.Stickers
                 return new []
                 {
                     AppStoreIcon,
+                    MessagesAppStoreIcon,
 
                     MessagesIpadPro2Icon,
                     MessagesIpad2Icon,
@@ -49,6 +50,8 @@ namespace Agens.Stickers
                 return new []
                 {
                     AppStore,
+                    MessagesAppStore,
+
                     MessagesIpadPro2,
                     MessagesIpad2,
                     MessagesiPhone2,
@@ -70,6 +73,7 @@ namespace Agens.Stickers
             {
                 return new []
                 {
+                    new Vector2(1024,1024),
                     new Vector2(1024,768),
 
                     new Vector2(148,110),
@@ -91,9 +95,13 @@ namespace Agens.Stickers
 
         #region AppStore
 
-        [Header("1024 x 768 px")]
+        [Header("1024 x 1024 px")]
         [SerializeField]
         private Texture2D appStore;
+
+        [Header("1024 x 768 px")]
+        [SerializeField]
+        private Texture2D messagesAppStore;
 
         /// <summary>
         /// 1024,768
@@ -106,6 +114,19 @@ namespace Agens.Stickers
                 {
                     return appStore;
                 }
+                return GetDefaultTexture(1024, 1024);
+            }
+        }
+
+
+        public Texture2D MessagesAppStore
+        {
+            get
+            {
+                if (Override)
+                {
+                    return messagesAppStore;
+                }
                 return GetDefaultTexture(1024, 768);
             }
         }
@@ -117,11 +138,25 @@ namespace Agens.Stickers
                 var texture = AppStore;
                 if (texture != null)
                 {
+                    return new StickerIcon(texture, 1024, 1024, StickerIcon.Idiom.IosMarketing, StickerIcon.Scale.Original);
+                }
+                return null;
+            }
+        }
+
+        public StickerIcon MessagesAppStoreIcon
+        {
+            get
+            {
+                var texture = MessagesAppStore;
+                if(texture != null)
+                {
                     return new StickerIcon(texture, 1024, 768, StickerIcon.Idiom.IosMarketing, StickerIcon.Scale.Original, "ios");
                 }
                 return null;
             }
         }
+
         #endregion
 
         public IconExportSettings Settings;


### PR DESCRIPTION
Thank you for writing this plugin! I noticed that after exporting a build to xCode there is now a Messages App Store icon as well as the App Store iOS.  However, there is only the option to add the App Store icon in Unity. 

This PR updates the plugin so both App Store icon and Message App Store icon are generated when building.