### PR TITLE
fix auto generate icon's error & platform protect

### DIFF
--- a/Assets/Stickers/Editor/AssetCatalog.cs
+++ b/Assets/Stickers/Editor/AssetCatalog.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -706,3 +707,4 @@ namespace UnityEditor.iOS.Xcode.Stickers
     }
 
 } // namespace UnityEditor.iOS.Xcode
+#endif

--- a/Assets/Stickers/Editor/PBX/Objects.cs
+++ b/Assets/Stickers/Editor/PBX/Objects.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System.Collections.Generic;
 using System.Collections;
 using System.Text.RegularExpressions;
@@ -891,3 +892,5 @@ namespace UnityEditor.iOS.Xcode.PBX
     }
 
 } // namespace UnityEditor.iOS.Xcode
+
+#endif

--- a/Assets/Stickers/Editor/PBX/Sections.cs
+++ b/Assets/Stickers/Editor/PBX/Sections.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -119,3 +120,4 @@ namespace UnityEditor.iOS.Xcode.PBX
     }
 
 } // UnityEditor.iOS.Xcode
+#endif

--- a/Assets/Stickers/Editor/PBX/Serializer.cs
+++ b/Assets/Stickers/Editor/PBX/Serializer.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -256,3 +257,4 @@ namespace UnityEditor.iOS.Xcode.PBX
     }
     
 } // namespace UnityEditor.iOS.Xcode
+#endif

--- a/Assets/Stickers/Editor/PBX/Utils.cs
+++ b/Assets/Stickers/Editor/PBX/Utils.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -352,3 +353,4 @@ namespace UnityEditor.iOS.Xcode.PBX
     }
 
 } // UnityEditor.iOS.Xcode
+#endif

--- a/Assets/Stickers/Editor/PBXProject.cs
+++ b/Assets/Stickers/Editor/PBXProject.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -1361,3 +1362,4 @@ namespace UnityEditor.iOS.Xcode.Stickers
     }
 
 } // namespace UnityEditor.iOS.Xcode
+#endif

--- a/Assets/Stickers/Editor/PBXProjectData.cs
+++ b/Assets/Stickers/Editor/PBXProjectData.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -683,3 +684,4 @@ namespace UnityEditor.iOS.Xcode
 
 } // namespace UnityEditor.iOS.Xcode
 
+#endif

--- a/Assets/Stickers/Editor/StickerPackEditor.cs
+++ b/Assets/Stickers/Editor/StickerPackEditor.cs
@@ -174,7 +174,7 @@ namespace Agens.Stickers
 
             GUI.Box(Rect.MinMaxRect(rect.xMin + 1f, rect.yMin, rect.xMax - 3f, rect.yMax), string.Empty);
 
-            if (Event.current.type != EventType.Repaint)
+            if (Event.current.type != UnityEngine.EventType.Repaint)
                 return;
 
             if (elementStyle == null)

--- a/Assets/Stickers/Editor/StickerTest.cs
+++ b/Assets/Stickers/Editor/StickerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#if UNITY_IOS
+using System.IO;
 using Agens;
 using UnityEngine;
 using UnityEditor;
@@ -48,3 +49,4 @@ namespace Agens.Stickers
         }
     }
 }
+#endif

--- a/Assets/Stickers/Editor/StickersBuildPostProcess.cs
+++ b/Assets/Stickers/Editor/StickersBuildPostProcess.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿#if UNITY_IOS
+using UnityEditor;
 using UnityEditor.Callbacks;
 
 namespace Agens.Stickers
@@ -17,3 +18,4 @@ namespace Agens.Stickers
         }
     }
 }
+#endif

--- a/Assets/Stickers/Editor/StickersExport.cs
+++ b/Assets/Stickers/Editor/StickersExport.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_IOS
+using System;
 using UnityEngine;
 using System.IO;
 using System.Linq;
@@ -373,3 +374,4 @@ namespace Agens.Stickers
         }
     }
 }
+#endif

--- a/Assets/Stickers/StickerPackIcon.cs
+++ b/Assets/Stickers/StickerPackIcon.cs
@@ -552,7 +552,7 @@ namespace Agens.Stickers
                 return null;
             }
 
-            var scaled = TextureScale.ScaledResized(appStore, width, height, Settings.BackgroundColor, Settings.FillPercentage / 100f, Settings.FilterMode, Settings.ScaleMode);
+            var scaled = TextureScale.ScaledResized(width == height ? appStore : messagesAppStore, width, height, Settings.BackgroundColor, Settings.FillPercentage / 100f, Settings.FilterMode, Settings.ScaleMode);
             if (scaled != null)
             {
                 scaled.name = width + "x" + height;

--- a/Assets/Stickers/TextureScale.cs
+++ b/Assets/Stickers/TextureScale.cs
@@ -15,7 +15,7 @@ namespace Agens.Stickers
             }
 
             var rtt = CreateScaledTexture(src,width,height,backgroundColor,fillPercentage,mode, anchor);
-
+            RenderTexture.active = rtt;
             var texR = new Rect(0,0,width,height);
             result.ReadPixels(texR,0,0,true);
             result.Apply(false);


### PR DESCRIPTION
It seems icon auto generate has some error. And add some platform protect for user's who not installed the ios platform of Unity.